### PR TITLE
fix: Add 'export' to MangerEvents

### DIFF
--- a/src/structures/Manager.ts
+++ b/src/structures/Manager.ts
@@ -643,7 +643,7 @@ export interface PlaylistData {
   tracks: Track[];
 }
 
-interface ManagerEvents {
+export interface ManagerEvents {
   nodeCreate: (node: Node) => void;
   nodeDestroy: (node: Node) => void;
   nodeConnect: (node: Node) => void;


### PR DESCRIPTION
make ManagerEvents accessible to other projects