### PR TITLE
fixes broken track loop 

### DIFF
--- a/src/structures/Node.ts
+++ b/src/structures/Node.ts
@@ -331,22 +331,19 @@ export class Node {
 
 	// Handle the case when a track ended and it's set to repeat (track or queue)
 	private handleRepeatedTrack(player: Player, track: Track, payload: TrackEndEvent): void {
-		player.queue.previous = player.queue.current;
-
-		if (payload.reason === "stopped") {
-			player.queue.current = player.queue.shift();
-			if (!player.queue.current) {
-				this.queueEnd(player, track, payload);
-				return;
-			}
-		} else {
-			player.queue.add(player.queue.current);
-			player.queue.current = player.queue.shift();
-		}
-
-		this.manager.emit("trackEnd", player, track, payload);
-		if (this.manager.options.autoPlay) player.play();
+   		if (player.trackRepeat) {
+       		player.queue.unshift(player.queue.current);
+   		} else if (player.queueRepeat) {
+        	player.queue.add(player.queue.current);
+    	}
+   		 player.queue.previous = player.queue.current;
+    		player.queue.current = player.queue.shift();
+    		this.manager.emit("trackEnd", player, track, payload);
+    		if (this.manager.options.autoPlay) {
+        		player.play();
+    		}
 	}
+
 
 	// Handle the case when there's another track in the queue
 	private playNextTrack(player: Player, track: Track, payload: TrackEndEvent): void {


### PR DESCRIPTION
I tested this by editing it after it was built, so I'm not sure if it works directly like this in TS. However, this fix addresses an issue where the track loop wouldn't function properly if other items were in the queue. For example, if you added two songs to the queue and enabled track loop, it wouldn't loop the current song playing. Instead, it would proceed to the next two songs before playing the song originally set to loop before the queue ended. This fix resolves that.