### PR TITLE
Revert "fixed loop issue"

### DIFF
--- a/src/structures/Node.ts
+++ b/src/structures/Node.ts
@@ -331,26 +331,21 @@ export class Node {
 
 	// Handle the case when a track ended and it's set to repeat (track or queue)
 	private handleRepeatedTrack(player: Player, track: Track, payload: TrackEndEvent): void {
-
-		if (player.trackRepeat) {
-			player.queue.unshift(player.queue.current);
-			} else if (player.queueRepeat) {
-				player.queue.add(player.queue.current);
-			}
-			player.queue.previous = player.queue.current;
-			player.queue.current = player.queue.shift();
-			this.manager.emit("trackEnd", player, track, payload);
+		player.queue.previous = player.queue.current;
 
 		if (payload.reason === "stopped") {
-		player.queue.current = player.queue.shift();
-		if (!player.queue.current) {
-			this.queueEnd(player, track, payload);
-			return;
+			player.queue.current = player.queue.shift();
+			if (!player.queue.current) {
+				this.queueEnd(player, track, payload);
+				return;
+			}
+		} else {
+			player.queue.add(player.queue.current);
+			player.queue.current = player.queue.shift();
 		}
-	}
-	if (this.manager.options.autoPlay) {
-		player.play();
-		}
+
+		this.manager.emit("trackEnd", player, track, payload);
+		if (this.manager.options.autoPlay) player.play();
 	}
 
 	// Handle the case when there's another track in the queue


### PR DESCRIPTION
Reverts Blackfort-Hosting/magmastream#192

@Nansess If 2 tracks in the queue and track loop is enabled, it goes to the other song, so basically track loop only now works if there is 1 song in the queue, debug and check if the issue is same for you.