### PR TITLE
Remove ClientUser type

### DIFF
--- a/src/structures/Player.ts
+++ b/src/structures/Player.ts
@@ -5,7 +5,7 @@ import { Queue } from "./Queue";
 import { Sizes, State, Structure, TrackSourceName, TrackUtils, VoiceState } from "./Utils";
 import * as _ from "lodash";
 import playerCheck from "../utils/playerCheck";
-import { ClientUser, Message, User } from "discord.js";
+import { Message, User } from "discord.js";
 
 export class Player {
 	/** The Queue for the Player. */
@@ -112,7 +112,7 @@ export class Player {
 	 * @param query
 	 * @param requester
 	 */
-	public search(query: string | SearchQuery, requester?: User | ClientUser): Promise<SearchResult> {
+	public search(query: string | SearchQuery, requester?: User): Promise<SearchResult> {
 		return this.manager.search(query, requester);
 	}
 
@@ -515,7 +515,7 @@ export interface Track {
 	/** The thumbnail of the track or null if it's a unsupported source. */
 	readonly thumbnail: string | null;
 	/** The user that requested the track. */
-	readonly requester: User | ClientUser | null;
+	readonly requester: User | null;
 	/** Displays the track thumbnail with optional size or null if it's a unsupported source. */
 	displayThumbnail(size?: Sizes): string;
 	/** Additional track info provided by plugins. */

--- a/src/structures/Utils.ts
+++ b/src/structures/Utils.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-empty-function, @typescript-eslint/no-unused-vars, @typescript-eslint/no-var-requires*/
-import { ClientUser, User } from "discord.js";
+import { User } from "discord.js";
 import { Manager } from "./Manager";
 import { Node, NodeStats } from "./Node";
 import { Player, Track, UnresolvedTrack } from "./Player";
@@ -70,7 +70,7 @@ export abstract class TrackUtils {
 	 * @param data
 	 * @param requester
 	 */
-	static build(data: TrackData, requester?: User | ClientUser): Track {
+	static build(data: TrackData, requester?: User): Track {
 		if (typeof data === "undefined") throw new RangeError('Argument "data" must be present.');
 
 		try {
@@ -127,7 +127,7 @@ export abstract class TrackUtils {
 	 * @param query
 	 * @param requester
 	 */
-	static buildUnresolved(query: string | UnresolvedQuery, requester?: User | ClientUser): UnresolvedTrack {
+	static buildUnresolved(query: string | UnresolvedQuery, requester?: User): UnresolvedTrack {
 		if (typeof query === "undefined") throw new RangeError('Argument "query" must be present.');
 
 		let unresolvedTrack: Partial<UnresolvedTrack> = {


### PR DESCRIPTION
Remove `ClientUser` type from everywhere where `User | ClientUser` was.

When you have a Typescript codebase, it throw an error and says
> Type 'User' is missing the following properties from type 'ClientUser': mfaEnabled, presence, verified, edit, and 7 more.

`ClientUser` extends `User` so no need to add it in the types

It seems to build correctly on my computer